### PR TITLE
Create klystrack.desktop

### DIFF
--- a/linux/klystrack.desktop
+++ b/linux/klystrack.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Klystrack
+Comment=Chiptune Tracker
+Exec=klystrack %f
+Type=Application
+Icon=klystrack.png
+Terminal=false
+Categories=AudioVideo;AudioVideoEditing
+Keywords=tracker;music;chipsong;
+MimeType=audio/kt;


### PR DESCRIPTION
this should be installed to /usr/share/applications
with an icon in /usr/share/icons/klystrack.png (or svg)

the freedesktop.org .desktop files integrates for some gui filemanagers, allowing user to select, open this kind of file with this application