### PR TITLE
Make 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,12 +86,12 @@ define directory_defs
  OBJS := $(OBJS) $$(OBJ)
  DEPS := $(DEPS) $$(DEP)
 
-objs.$(CFG)/$(2)%.o: src/$(1)%$(EXT)
+objs.$(CFG)/$(2)%.o: src/$(1)%$(EXT) src/version.h src/version_number.h
 	$(MSG) "Compiling $$(notdir $$<)..."
 	$(Q)mkdir -p objs.$(CFG)
 	$(Q)$(CC) $(INCLUDEFLAGS) -c $(CFLAGS) -o $$@ $$<
 
-deps/$(CFG)_$(2)%.d: src/$(1)%$(EXT)
+deps/$(CFG)_$(2)%.d: src/$(1)%$(EXT) src/version.h src/version_number.h
 	$(Q)mkdir -p deps
 	$(MSG) "Generating dependencies for $$(notdir $$<)..."
 	$(Q)set -e ; $(CDEP) $(INCLUDEFLAGS) $$< > $$@.$$$$$$$$; \

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,6 @@ CFLAGS := $(MACHINE) -ftree-vectorize -std=gnu99 -Wno-strict-aliasing -Werror
 ifdef COMSPEC
 	TARGET := $(TARGET).exe
 	ARCHIVE := $(ARCHIVE).zip
-	SDLFLAGS := -I c:/mingw/include/SDL2
-	SDLLIBS :=  -lSDL2main -lSDL2 -lSDL2_image -lwinmm
 	CFLAGS += -mthreads
 	ZIP := zip -r ../$(ARCHIVE) .
 	ZIPEXT := unzip
@@ -35,8 +33,6 @@ else
 	ZIP := tar czf
 	DLLS =
 	ARCHIVE := $(ARCHIVE).tar.gz
-	SDLFLAGS := `sdl2-config --cflags` -U_FORTIFY_SOURCE
-	SDLLIBS := `sdl2-config --libs` -lSDL2_image
 endif
 
 ifdef COMSPEC


### PR DESCRIPTION
a couple improvements, including addition of an install target (test via `make DESTDIR=foobar install`).

i'd also like to install examples, but the split of songs/n00bstar-songs and instru... is a bit annoying because they all need extra rules. could i just move the n00bstar stuff into the respective directory? e.g.
```
 rename examples/songs/{n00bstar-examples/Arps.kt => n00bstar-Arps.kt} (100%)
```
or even leave the n00bstar prefix away entirely ? i suspect klystrack allows to add comments, so the author could be credited that way.
however's that's stuff for the next PR. let me know what you think.