### PR TITLE
Fixed the "double free" .wav-saving issue

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -725,8 +725,8 @@ void export_channels_action(void *a, void*b, void*c)
 
 			if (f)
 			{
-				export_wav(&mused.song, mused.mus.cyd->wavetable_entries, f, i);
-				fclose(f);
+				if (export_wav(&mused.song, mused.mus.cyd->wavetable_entries, f, i))
+					fclose(f); // Call only if not aborted
 			}
 		}
 	}

--- a/src/export.c
+++ b/src/export.c
@@ -38,7 +38,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 extern GfxDomain *domain;
 
-void export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel)
+bool export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel)
 {
 	MusEngine mus;
 	CydEngine cyd;
@@ -129,6 +129,8 @@ void export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel)
 		}
 	}
 	
+	return true; // Successful (not aborted)
+	
 abort:;
 	
 	ww_finish(ww);
@@ -138,5 +140,7 @@ abort:;
 	cyd_deinit(&cyd);
 	
 	song->flags &= ~MUS_NO_REPEAT;
+	
+	return false; // Aborted
 }
 

--- a/src/export.h
+++ b/src/export.h
@@ -28,6 +28,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 #include "snd/music.h"
 
-void export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel);
+bool export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel);
 
 #endif


### PR DESCRIPTION
This bug was reported in https://github.com/kometbomb/klystrack/issues/287 . I was affected myself and decided to fix that.

It seems to have been an issue that fclose(f) is called twice: Once in export_wav() and once in the function calling that. I've made it so that export_wav() returns a boolean allowing for checking whether calling fclose() is still needed.