### PR TITLE
Followup on .wav-saving fix

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -677,8 +677,8 @@ void export_wav_action(void *a, void*b, void*c)
 
 		if (f)
 		{
-			export_wav(&mused.song, mused.mus.cyd->wavetable_entries, f, -1);
-			fclose(f);
+			if(export_wav(&mused.song, mused.mus.cyd->wavetable_entries, f, -1))
+				fclose(f); // Call only if not aborted
 		}
 	}
 }


### PR DESCRIPTION
Sorry to bother you again, just a quick followup on the .wav-saving fix from https://github.com/kometbomb/klystrack/pull/289.

It turns out I missed one export_wav call before. I double checked all files just to be sure this time so this doesn't happen again.