### PR TITLE
Fixed double fclose(f) when calling export_wav

### DIFF
--- a/src/action.c
+++ b/src/action.c
@@ -677,8 +677,8 @@ void export_wav_action(void *a, void*b, void*c)
 
 		if (f)
 		{
-			if(export_wav(&mused.song, mused.mus.cyd->wavetable_entries, f, -1))
-				fclose(f); // Call only if not aborted
+			export_wav(&mused.song, mused.mus.cyd->wavetable_entries, f, -1);
+			// f is closed inside of export_wav (inside of ww_finish)
 		}
 	}
 }
@@ -725,8 +725,8 @@ void export_channels_action(void *a, void*b, void*c)
 
 			if (f)
 			{
-				if (export_wav(&mused.song, mused.mus.cyd->wavetable_entries, f, i))
-					fclose(f); // Call only if not aborted
+				export_wav(&mused.song, mused.mus.cyd->wavetable_entries, f, i);
+				// f is closed inside of export_wav (inside of ww_finish)
 			}
 		}
 	}

--- a/src/export.c
+++ b/src/export.c
@@ -38,7 +38,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 extern GfxDomain *domain;
 
-bool export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel)
+void export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel)
 {
 	MusEngine mus;
 	CydEngine cyd;
@@ -129,8 +129,6 @@ bool export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel)
 		}
 	}
 	
-	return true; // Successful (not aborted)
-	
 abort:;
 	
 	ww_finish(ww);
@@ -140,7 +138,5 @@ abort:;
 	cyd_deinit(&cyd);
 	
 	song->flags &= ~MUS_NO_REPEAT;
-	
-	return false; // Aborted
 }
 

--- a/src/export.c
+++ b/src/export.c
@@ -38,8 +38,10 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 extern GfxDomain *domain;
 
-void export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel)
+bool export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel)
 {
+	bool success = false;
+	
 	MusEngine mus;
 	CydEngine cyd;
 	
@@ -129,6 +131,8 @@ void export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel)
 		}
 	}
 	
+	success = true;
+	
 abort:;
 	
 	ww_finish(ww);
@@ -138,5 +142,7 @@ abort:;
 	cyd_deinit(&cyd);
 	
 	song->flags &= ~MUS_NO_REPEAT;
+	
+	return success;
 }
 

--- a/src/export.h
+++ b/src/export.h
@@ -28,6 +28,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 #include "snd/music.h"
 
-bool export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel);
+void export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel);
 
 #endif

--- a/src/export.h
+++ b/src/export.h
@@ -28,6 +28,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 #include "snd/music.h"
 
-void export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel);
+bool export_wav(MusSong *song, CydWavetableEntry * entry, FILE *f, int channel);
 
 #endif


### PR DESCRIPTION
Turns out fclose(f) is called inside of ww_finish, which is called inside of export_wav. Therefore, closing the already closed file after calling export_wav would result in a crash.

This should fix #293.