### PR TITLE
Combine sequential mouse movement events

### DIFF
--- a/src/help.c
+++ b/src/help.c
@@ -342,9 +342,10 @@ int helpbox(const char *title, GfxDomain *domain, GfxSurface *gfx, const Font *l
 			
 			if (e.type != SDL_MOUSEMOTION || (e.motion.state)) ++got_event;
 			
-			// ensure the last event is a mouse click so it gets passed to the draw/event code
-			
-			if (e.type == SDL_MOUSEBUTTONDOWN || (e.type == SDL_MOUSEMOTION && e.motion.state)) break; 
+			// Process mouse click events immediately, and batch mouse motion events
+			// (process the last one) to fix lag with high poll rate mice on Linux.
+			if (should_process_mouse(&e))
+				break;
 		}
 		
 		if (got_event || gfx_domain_is_next_frame(domain))

--- a/src/import/hubdialog.c
+++ b/src/import/hubdialog.c
@@ -221,9 +221,10 @@ int hub_view(hubbard_t *hub)
 			
 			if (e.type != SDL_MOUSEMOTION || (e.motion.state)) ++got_event;
 			
-			// ensure the last event is a mouse click so it gets passed to the draw/event code
-			
-			if (e.type == SDL_MOUSEBUTTONDOWN || (e.type == SDL_MOUSEMOTION && e.motion.state)) break; 
+			// Process mouse click events immediately, and batch mouse motion events
+			// (process the last one) to fix lag with high poll rate mice on Linux.
+			if (should_process_mouse(&e))
+				break;
 		}
 		
 		if (got_event || gfx_domain_is_next_frame(domain))

--- a/src/main.c
+++ b/src/main.c
@@ -491,9 +491,9 @@ int main(int argc, char **argv)
 
 			if (e.type != SDL_MOUSEMOTION || (e.motion.state) || (e.type == SDL_MOUSEMOTION && mused.mode == MENU)) ++got_event;
 
-			// ensure the last event is a mouse click so it gets passed to the draw/event code
-
-			if (e.type == SDL_MOUSEBUTTONDOWN || (e.type == SDL_MOUSEMOTION && e.motion.state))
+			// Process mouse click events immediately, and batch mouse motion events
+			// (process the last one) to fix lag with high poll rate mice on Linux.
+			if (should_process_mouse(&e))
 				break;
 		}
 


### PR DESCRIPTION
Previously on Linux (not Windows), if you opened Klystrack and dragged with a high polling rate mouse, the program would lag processing SDL_MOUSEMOTION events and redrawing the screen (#299). This fixes the bug.

Note that this PR changes the submodule to point to a commit that only exists in my fork (https://github.com/nyanpasu64/klystron/tree/fix-high-refresh-mouse), *and* pulls in changes from klystron on top of my own changes. To my current understanding, I'd merge the klystron changes, then change this PR to point to the merge or cherry-pick commit (unless you know a better way).

Fixes #299.